### PR TITLE
Refresh the iframe

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## v1.3.0
 
 * Refresh the report when a new error is preventing the restart #8
+* Better handling of server disconnection #8
 
 ## v1.2.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,17 @@
+## v1.2.0
+
+* Play the sound on checkbox check as a discovery mechanism #5
+* Immediate notification #6
+* Bugfix: broken HTML labels #7
+
+## v1.1.0
+
+* Bundle the alert sound instead of loading a Youtube iframe #3
+
+## v1.0.1
+
+* Bugfix: ReferenceError in Meteor 1.2 #1
+
+## v1.0.0
+
+* Initial release

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## v1.3.0
+
+* Refresh the report when a new error is preventing the restart #8
+
 ## v1.2.0
 
 * Play the sound on checkbox check as a discovery mechanism #5

--- a/package.js
+++ b/package.js
@@ -13,7 +13,6 @@ Package.onUse(function(api) {
   api.use([
     'ecmascript',
     'http',
-    'reactive-var',
     'tracker',
     'less',
     'meteor'


### PR DESCRIPTION
This fixes the following case:
1. We report an error
2. The user fix it but there is another error preventing the restart

Previously we didn't notice anything and would still display the old (fixed)
error. With this commit, we now refresh the iframe and re-run the notifications.
